### PR TITLE
[master] fix keep variable

### DIFF
--- a/HyperAPI/hyper_api/variable.py
+++ b/HyperAPI/hyper_api/variable.py
@@ -167,7 +167,7 @@ class Variable(Base):
             data = {'updateFields': {varname: {'ignored': False }}}
             returned_json = self.__api.Datasets.metadata(project_ID=self.project_id, dataset_ID=self.dataset_id, json=data)
             self.__json_returned['ignored'] = list(filter(lambda x: x.get('varName') == self.name, returned_json['metadata']['variables']))[0].get('ignored')
-        elif not self.is_ignored:
+        elif self.is_ignored:
             data = {'changedMetadata': [self.name]}
             self.__api.Datasets.metadata(project_ID=self.project_id, dataset_ID=self.dataset_id, json=data)
             self.__json_returned = self._update()

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Version 7
 
+### 7.0.11 
+- Fix keep variable method
+
 ### 7.0.9 
 - Adding Time Series Forecasting Model
 


### PR DESCRIPTION
Note that a test assertion should be added in API tests in Hypercube sources

A package has been generated: HyperAPI 7.0.11
but it was then deleted from pypi because it was failing when trying to get the list of projects on local
~\AppData\Roaming\Python\Python36\site-packages\HyperAPI\hyper_api\project.py in is_default(self)
    226         """
    227         if self.__api.session.version >= self.__api.session.version.__class__('3.6'):
--> 228             defaultProjectId = self.__api.Settings._getusersettings().get('defaultProjectId')
    229         else:
    230             defaultProjectId = self.__api.Projects.projects().get('defaultProject')

AttributeError: 'Settings' object has no attribute '_getusersettings'